### PR TITLE
Add counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # simple-raster-processing
 A research project into creating a web request raster processing pipeline using open source python tools
+
+### Get started
+Start Vagrant by providing it with an ENV which points to a directory on your host which containers GeoTiffs:
+```bash
+DATA_DIR=~/my/shapes vagrant up
+```
+
+### Request a count
+```
+curl -X POST "http://localhost:8080/counts?filename=<your_file.tiff>"
+```
+
+where `<your_file.tiff>` is a GeoTiff in the `DATA_DIR` directory.
+
+Presently, it's assumed that the raster is large enough to have data cells at the window:
+`((10000, 10350), (10000, 10350))`
+but that's a temporary restriction while this work progresses.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,8 @@ Vagrant.configure(2) do |config|
   # Geop Flask debug server
   config.vm.network :forwarded_port, guest: 8081, host: 8081
 
+  # Sync a data directory
+  #config.vm.synced_folder "~/shapes/", "/vagrant/src/shapes"
 
   # Change working directory to /vagrant upon session start.
   config.vm.provision "shell", inline: <<SCRIPT

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,8 +19,8 @@ Vagrant.configure(2) do |config|
   # Geop Flask debug server
   config.vm.network :forwarded_port, guest: 8081, host: 8081
 
-  # Sync a data directory
-  #config.vm.synced_folder "~/shapes/", "/vagrant/src/shapes"
+  # Sync a data directory which contains rasters on the host
+  config.vm.synced_folder ENV['DATA_DIR'], "/vagrant/data"
 
   # Change working directory to /vagrant upon session start.
   config.vm.provision "shell", inline: <<SCRIPT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,4 @@ services:
       - "8081:8081"
     volumes:
       - ./src/geop:/usr/src/geop
+      - ./data:/usr/data

--- a/src/Dockerfile.geop
+++ b/src/Dockerfile.geop
@@ -4,11 +4,26 @@ MAINTAINER Azavea
 
 RUN apt-get update
 
+RUN apt-get install -y software-properties-common
+RUN add-apt-repository ppa:ubuntugis/ppa
+
+RUN apt-get install -y \
+        gdal-bin \
+        libgdal-dev \
+        libgeos-dev
+
 RUN pip install --upgrade pip
+
+# numpy needs to be installed prior to additional dependencies
+RUN pip install --no-cache-dir \
+    numpy
+
 COPY requirements.txt /tmp/
-RUN pip install --no-cache-dir -r /tmp/requirements.txt
+RUN pip install --no-cache-dir -r \
+    /tmp/requirements.txt
 
 COPY ./geop /usr/src/geop
+#COPY ./shapes/test.tif /usr/src/geop/data/test.tif
 
 WORKDIR /usr/src/geop
 

--- a/src/Dockerfile.geop
+++ b/src/Dockerfile.geop
@@ -19,7 +19,6 @@ RUN \
                  libgdal-dev
 
 COPY ./geop /usr/src/geop
-#COPY ./shapes/test.tif /usr/src/geop/data/test.tif
 
 WORKDIR /usr/src/geop
 

--- a/src/Dockerfile.geop
+++ b/src/Dockerfile.geop
@@ -2,25 +2,21 @@ FROM quay.io/azavea/flask:0.11
 
 MAINTAINER Azavea
 
-RUN apt-get update
-
-RUN apt-get install -y software-properties-common
-RUN add-apt-repository ppa:ubuntugis/ppa
-
-RUN apt-get install -y \
-        gdal-bin \
-        libgdal-dev \
-        libgeos-dev
-
-RUN pip install --upgrade pip
-
-# numpy needs to be installed prior to additional dependencies
-RUN pip install --no-cache-dir \
-    numpy
+RUN \
+      apt-get update && apt-get install -y --no-install-recommends \
+              gdal-bin \
+              libgdal-dev \
+      && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /tmp/
-RUN pip install --no-cache-dir -r \
-    /tmp/requirements.txt
+
+RUN \
+      pip install --no-cache-dir \
+          numpy==$(grep "numpy" /tmp/requirements.txt | cut -d= -f3) \
+      && pip install --no-cache-dir -r /tmp/requirements.txt \
+      && rm /tmp/requirements.txt \
+      && apt-get purge -y --auto-remove \
+                 libgdal-dev
 
 COPY ./geop /usr/src/geop
 #COPY ./shapes/test.tif /usr/src/geop/data/test.tif
@@ -29,11 +25,11 @@ WORKDIR /usr/src/geop
 
 EXPOSE 8080
 
-CMD ["-w", "2", \
+CMD ["-w", "1", \
      "-b", "0.0.0.0:8080", \
      "--reload", \
      "--log-level", "info", \
      "--error-logfile", "-", \
      "--forwarded-allow-ips", "*", \
      "-k", "gevent", \
-"main:app"]
+     "main:app"]

--- a/src/geop/main.py
+++ b/src/geop/main.py
@@ -1,6 +1,17 @@
 from flask import Flask
+import rasterio
+
+import os.path
 
 app = Flask(__name__)
+
+
+@app.route('/histogram', methods=['POST'])
+def histogram():
+    # Testing that the library is available
+    print os.path.isfile('/vagrant/shapes/DelDem4ad8.tif')
+    #src = rasterio.open('/vagrant/shapes/DelDem4ad8.tif')
+    #return src.read(1)
 
 
 @app.route('/ping', methods=['GET'])

--- a/src/geop/main.py
+++ b/src/geop/main.py
@@ -1,22 +1,60 @@
-from flask import Flask
-import rasterio
+import os
+import time
 
-import os.path
+from flask import Flask, request, jsonify
+import numpy as np
+import rasterio
 
 app = Flask(__name__)
 
-
-@app.route('/histogram', methods=['POST'])
-def histogram():
-    # Testing that the library is available
-    print os.path.isfile('/vagrant/shapes/DelDem4ad8.tif')
-    #src = rasterio.open('/vagrant/shapes/DelDem4ad8.tif')
-    #return src.read(1)
+DATA_PATH = '/usr/data/'
 
 
-@app.route('/ping', methods=['GET'])
-def ping():
-    return 'pong'
+@app.route('/counts', methods=['POST'])
+def count():
+    """
+    Perform a rudimentary cell count analysis on a portion of a
+    provided raster
+
+    Query String Args:
+        filename: file name of a valid geotiff in DATA_DIR
+    """
+
+    raster = request.args.get('filename')
+    if not raster:
+        return handle_error('filename parameter is required')
+
+    raster_path = os.path.join(DATA_PATH, raster)
+    if not os.path.isfile(raster_path):
+        return handle_error('{} is not valid file in DATA_DIR'.format(raster))
+
+    counts = {}
+    start = time.clock()
+    with rasterio.open(raster_path) as src:
+        w = src.read(1, window=((10000, 10350), (10000, 10350)))
+
+        for idx, cell in np.ndenumerate(w):
+            cell_val = str(cell)
+
+            if cell_val in counts:
+                counts[cell_val] += 1
+            else:
+                counts[cell_val] = 1
+
+    elapsed = time.clock() - start
+    cells = reduce(lambda s, key: s + counts[key], counts.keys(), 0)
+
+    return jsonify({
+        'time': elapsed,
+        'cellCount': cells,
+        'counts': counts,
+    })
+
+
+def handle_error(msg, code=400):
+    response = jsonify({'message': msg})
+    response.status_code = code
+    return response
 
 
 if __name__ == '__main__':

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,4 @@
+numpy==1.11.1
 rasterio==0.36.0
 requests==2.10.0
 shapely==1.5.15

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,1 +1,3 @@
+rasterio==0.36.0
 requests==2.10.0
+shapely==1.5.15


### PR DESCRIPTION
A rudimentary read operation on a raster saved to local disk.
- Adds a way to expose a raster data from host to container
- Developed against a typical national scale, 30m raster
- Takes a fixed window of data and does some summary statistics
- Times the basic read and count iteration

I didn't spend any time on any optimization of reading or iterating over the numpy results, this is mostly a first step proof of concept.

Locally, running against the gSSURGO Hydrologic Soils Group raster produced these results:

``` bash
curl -X POST "http://localhost:8080/counts?filename=hydrosoils_conus_30m.tif" 
{
  "cellCount": 122500, 
  "counts": {
    "0": 2961, 
    "1": 6022, 
    "2": 84840, 
    "3": 17841, 
    "4": 2969, 
    "7": 7867
  }, 
  "time": 0.5682389999999997
}
```
