### PR TITLE
Add scripts for raster read instrumentation

### DIFF
--- a/src/geop/perf/perf.py
+++ b/src/geop/perf/perf.py
@@ -1,0 +1,119 @@
+import os
+import sys
+from shapely.geometry import Polygon
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import geo_utils as gp  # noqa
+
+# 21,306 sq km
+large_geom = Polygon([[1526562.40124153485521674,2050242.57054176111705601], [1666966.8961625280790031,2054540.66732505685649812],[1662668.79937923233956099, 1899809.18312641140073538],[1523697.00338600436225533,1899809.18312641140073538],[1526562.40124153485521674,2050242.57054176111705601]])  # noqa
+
+# 921 sq km
+med_geom = Polygon([[1615747.90949492086656392,1990427.39030756242573261],[1644939.15014813770540059,1990427.39030756242573261],[1644222.80068425508216023, 1958191.66443284461274743],[1615747.90949492086656392,1958728.92653075652197003],[1615747.90949492086656392,1990427.39030756242573261]]) # noqa
+
+# 0.45 sq km
+sm_geom = Polygon([[1638682.28529953747056425,1974555.77249841345474124],[1638699.07474009715951979,1973945.75615807599388063],[1639426.61716435290873051, 1973951.35263826255686581],[1639415.42420397978276014,1974555.77249841345474124],[1638682.28529953747056425,1974555.77249841345474124]])  # noqa
+
+"""
+Large geom sizes
+"""
+
+
+# Full NLCD: tif | none | 1024x1024
+def read_lrg_1024_none():
+    gp.mask_geom_on_raster(large_geom, '/usr/data/nlcd/nlcd_1024.tif')
+
+
+# Full NLCD: tif | none | 512x512
+def read_lrg_512_none():
+    gp.mask_geom_on_raster(large_geom, '/usr/data/nlcd/nlcd_512.tif')
+
+
+# Full NLCD: tif | none | 256x256
+def read_lrg_256_none():
+    gp.mask_geom_on_raster(large_geom, '/usr/data/nlcd/nlcd.tif')
+
+
+# Full NLCD: tif | lzw | 512x512
+def read_lrg_512_lzw():
+    gp.mask_geom_on_raster(large_geom, '/usr/data/nlcd/nlcd_512_lzw.tif')
+
+
+# Full NLCD: tif | lzw | 256x256
+def read_lrg_256_lzw():
+    gp.mask_geom_on_raster(large_geom, '/usr/data/nlcd/nlcd_cp.tif')
+
+
+# Full NLCD: tif | packbits | 256x256
+def read_lrg_256_pb():
+    gp.mask_geom_on_raster(large_geom, '/usr/data/nlcd/nlcd_cp_pb.tif')
+
+
+"""
+Medium geom sizes
+"""
+
+
+# Full NLCD: tif | none | 1024x1024
+def read_med_1024_none():
+    gp.mask_geom_on_raster(med_geom, '/usr/data/nlcd/nlcd_1024.tif')
+
+
+# Full NLCD: tif | none | 512x512
+def read_med_512_none():
+    gp.mask_geom_on_raster(med_geom, '/usr/data/nlcd/nlcd_512.tif')
+
+
+# Full NLCD: tif | none | 256x256
+def read_med_256_none():
+    gp.mask_geom_on_raster(med_geom, '/usr/data/nlcd/nlcd.tif')
+
+
+# Full NLCD: tif | lzw | 512x512
+def read_med_512_lzw():
+    gp.mask_geom_on_raster(med_geom, '/usr/data/nlcd/nlcd_512_lzw.tif')
+
+
+# Full NLCD: tif | lzw | 256x256
+def read_med_256_lzw():
+    gp.mask_geom_on_raster(med_geom, '/usr/data/nlcd/nlcd_cp.tif')
+
+
+# Full NLCD: tif | packbits | 256x256
+def read_med_256_pb():
+    gp.mask_geom_on_raster(med_geom, '/usr/data/nlcd/nlcd_cp_pb.tif')
+
+
+"""
+Small geom sizes
+"""
+
+
+# Full NLCD: tif | none | 1024x1024
+def read_sm_1024_none():
+    gp.mask_geom_on_raster(sm_geom, '/usr/data/nlcd/nlcd_1024.tif')
+
+
+# Full NLCD: tif | none | 512x512
+def read_sm_512_none():
+    gp.mask_geom_on_raster(sm_geom, '/usr/data/nlcd/nlcd_512.tif')
+
+
+# Full NLCD: tif | none | 256x256
+def read_sm_256_none():
+    gp.mask_geom_on_raster(sm_geom, '/usr/data/nlcd/nlcd.tif')
+
+
+# Full NLCD: tif | lzw | 512x512
+def read_sm_512_lzw():
+    gp.mask_geom_on_raster(sm_geom, '/usr/data/nlcd/nlcd_512_lzw.tif')
+
+
+# Full NLCD: tif | lzw | 256x256
+def read_sm_256_lzw():
+    gp.mask_geom_on_raster(sm_geom, '/usr/data/nlcd/nlcd_cp.tif')
+
+
+# Full NLCD: tif | packbits | 256x256
+def read_sm_256_pb():
+    gp.mask_geom_on_raster(sm_geom, '/usr/data/nlcd/nlcd_cp_pb.tif')

--- a/src/geop/perf/perf.sh
+++ b/src/geop/perf/perf.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+set -x
+
+for size in "lrg" "med" "sm"; do
+    python -m timeit -s "import perf" "perf.read_${size}_1024_none()"
+    python -m timeit -s "import perf" "perf.read_${size}_512_none()"
+    python -m timeit -s "import perf" "perf.read_${size}_256_none()"
+    python -m timeit -s "import perf" "perf.read_${size}_512_lzw()"
+    python -m timeit -s "import perf" "perf.read_${size}_256_lzw()"
+    python -m timeit -s "import perf" "perf.read_${size}_256_pb()"
+done
+
+for size in "lrg" "med" "sm"; do
+    python -m timeit -s "import perf_tile as perf" "perf.read_${size}_1024_none()"
+    python -m timeit -s "import perf_tile as perf" "perf.read_${size}_512_none()"
+    python -m timeit -s "import perf_tile as perf" "perf.read_${size}_256_none()"
+    python -m timeit -s "import perf_tile as perf" "perf.read_${size}_512_lzw()"
+    python -m timeit -s "import perf_tile as perf" "perf.read_${size}_256_lzw()"
+    python -m timeit -s "import perf_tile as perf" "perf.read_${size}_256_pb()"
+done

--- a/src/geop/perf/perf_tile.py
+++ b/src/geop/perf/perf_tile.py
@@ -1,0 +1,119 @@
+import os
+import sys
+from shapely.geometry import Polygon
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import geo_utils as gp  # noqa
+
+# 21,306 sq km
+large_geom = Polygon([[1526562.40124153485521674,2050242.57054176111705601], [1666966.8961625280790031,2054540.66732505685649812],[1662668.79937923233956099, 1899809.18312641140073538],[1523697.00338600436225533,1899809.18312641140073538],[1526562.40124153485521674,2050242.57054176111705601]])  # noqa
+
+# 921 sq km
+med_geom = Polygon([[1615747.90949492086656392,1990427.39030756242573261],[1644939.15014813770540059,1990427.39030756242573261],[1644222.80068425508216023, 1958191.66443284461274743],[1615747.90949492086656392,1958728.92653075652197003],[1615747.90949492086656392,1990427.39030756242573261]]) # noqa
+
+# 0.45 sq km
+sm_geom = Polygon([[1638682.28529953747056425,1974555.77249841345474124],[1638699.07474009715951979,1973945.75615807599388063],[1639426.61716435290873051, 1973951.35263826255686581],[1639415.42420397978276014,1974555.77249841345474124],[1638682.28529953747056425,1974555.77249841345474124]])  # noqa
+
+"""
+Large geom sizes
+"""
+
+
+# Full NLCD: tif | none | 1024x1024
+def read_lrg_1024_none():
+    gp.tile_read(large_geom, '/usr/data/nlcd/nlcd_1024.tif')
+
+
+# Full NLCD: tif | none | 512x512
+def read_lrg_512_none():
+    gp.tile_read(large_geom, '/usr/data/nlcd/nlcd_512.tif')
+
+
+# Full NLCD: tif | none | 256x256
+def read_lrg_256_none():
+    gp.tile_read(large_geom, '/usr/data/nlcd/nlcd.tif')
+
+
+# Full NLCD: tif | lzw | 512x512
+def read_lrg_512_lzw():
+    gp.tile_read(large_geom, '/usr/data/nlcd/nlcd_512_lzw.tif')
+
+
+# Full NLCD: tif | lzw | 256x256
+def read_lrg_256_lzw():
+    gp.tile_read(large_geom, '/usr/data/nlcd/nlcd_cp.tif')
+
+
+# Full NLCD: tif | packbits | 256x256
+def read_lrg_256_pb():
+    gp.tile_read(large_geom, '/usr/data/nlcd/nlcd_cp_pb.tif')
+
+
+"""
+Medium geom sizes
+"""
+
+
+# Full NLCD: tif | none | 1024x1024
+def read_med_1024_none():
+    gp.tile_read(med_geom, '/usr/data/nlcd/nlcd_1024.tif')
+
+
+# Full NLCD: tif | none | 512x512
+def read_med_512_none():
+    gp.tile_read(med_geom, '/usr/data/nlcd/nlcd_512.tif')
+
+
+# Full NLCD: tif | none | 256x256
+def read_med_256_none():
+    gp.tile_read(med_geom, '/usr/data/nlcd/nlcd.tif')
+
+
+# Full NLCD: tif | lzw | 512x512
+def read_med_512_lzw():
+    gp.tile_read(med_geom, '/usr/data/nlcd/nlcd_512_lzw.tif')
+
+
+# Full NLCD: tif | lzw | 256x256
+def read_med_256_lzw():
+    gp.tile_read(med_geom, '/usr/data/nlcd/nlcd_cp.tif')
+
+
+# Full NLCD: tif | packbits | 256x256
+def read_med_256_pb():
+    gp.tile_read(med_geom, '/usr/data/nlcd/nlcd_cp_pb.tif')
+
+
+"""
+Small geom sizes
+"""
+
+
+# Full NLCD: tif | none | 1024x1024
+def read_sm_1024_none():
+    gp.tile_read(sm_geom, '/usr/data/nlcd/nlcd_1024.tif')
+
+
+# Full NLCD: tif | none | 512x512
+def read_sm_512_none():
+    gp.tile_read(sm_geom, '/usr/data/nlcd/nlcd_512.tif')
+
+
+# Full NLCD: tif | none | 256x256
+def read_sm_256_none():
+    gp.tile_read(sm_geom, '/usr/data/nlcd/nlcd.tif')
+
+
+# Full NLCD: tif | lzw | 512x512
+def read_sm_512_lzw():
+    gp.tile_read(sm_geom, '/usr/data/nlcd/nlcd_512_lzw.tif')
+
+
+# Full NLCD: tif | lzw | 256x256
+def read_sm_256_lzw():
+    gp.tile_read(sm_geom, '/usr/data/nlcd/nlcd_cp.tif')
+
+
+# Full NLCD: tif | packbits | 256x256
+def read_sm_256_pb():
+    gp.tile_read(sm_geom, '/usr/data/nlcd/nlcd_cp_pb.tif')


### PR DESCRIPTION
### Overview

Some crude scripts to measure the speed at which `Byte` rasters can be read using different file format options.  I haven't run similar metrics on rasters of other value types, they may have different results.

By focusing on just reads by `rasterio`/`gdal`, I'm trying to optimize the file format for various sizes of windowed reads while taking into consideration having to potentially copy and store multiple rasters on disk and attach them to compute instances.  Once the raster data is read in, the source format shouldn't matter since they are then operated on as `numpy ndarrays`.  I tried different various file formats, internal tiling block sizes and compression formats in my testing, and quickly found that GeoTiffs with _some_ internal tiling block size performed best, so I then narrowed the scope to test _which_ size had the best performance when reading in large, medium and small windows of data, both as a "full" read and a "decimated/resampled" read.  I then tried using both `LZW` and `PACKBITS` compression methods (they were the two most commonly cited algorithms) to see how much of an impact for size on disk and read speeds they added.  When it became clear that a certain block size was slower, I didn't attempt additional compression on that size.
### Results

_TL;DR:_ internally tiled `512x512` tifs with `LZW` compression are a good mix of speed and size on disk, across various window sizes, including decimated reads.  The `LZW` compression at worst adds single digit millisecond read time to the raw file, and at best is faster.  It also reduced file size on disk by about 93%.  `PACKBITS` may be faster at very small reads, but `LZW` seems to perform better overall.  Eyeballing memory usage for each run showed no significant deviation in consumption between different block sizes.

As a comparison, the NLCD dataset, which is my primary testing source, comes natively in a 64x64 block size in an IMG format with no compression and is 3x slower than the worst results in the table below.  I did not pursue that structure in the final testing and have now started using `512 LZW` as my actual test data, with noticeable improvements. 

_Tests were run on a laptop with an SSD, data on a synced directory to a VM constrained with 2 cpu and 2gb RAM_
#### Full Read

| block size | compression | size (GB) | read lg (ms) | read med (ms) | read sm (ms) |
| --- | --- | --- | --- | --- | --- |
| 1024 | none | 16 | 224 | 37.9 | 11.8 |
| 512 | none | 16 | 200 * | 26.4 * | 12.7 |
| 256 | none | 16 | 230 | 36.3 | 26.8 |
| 512 | lzw | 1.1 | 200 * | 28.1 | 9.9 * |
| 256 | lzw | 1.1 | 233 | 31.4 | 17.5 |
| 256 | pb | 2.5 | 240 | 32. 1 | 15.9 |
#### Decimated Read

| block size | compression | size (GB) | read lg (ms) | read med (ms) | read sm (ms) |
| --- | --- | --- | --- | --- | --- |
| 1024 | none | 16 | 166 | 32.9 | 11.4 |
| 512 | none | 16 | 144 * | 22.9 * | 11.2 |
| 256 | none | 16 | 191 | 30.7 | 22 |
| 512 | lzw | 1.1 | 144 * | 23.1 | 9.76 * |
| 256 | lzw | 1.1 | 175 | 27.9 | 26.3 |
| 256 | pb | 2.5 | 188 | 27.9 | 16.6 |
#### Representative raw results

``` bash
+ for size in '"lrg"' '"med"' '"sm"'
+ python -m timeit -s 'import perf' 'perf.read_lrg_1024_none()'
10 loops, best of 3: 224 msec per loop
+ python -m timeit -s 'import perf' 'perf.read_lrg_512_none()'
10 loops, best of 3: 200 msec per loop
+ python -m timeit -s 'import perf' 'perf.read_lrg_256_none()'
10 loops, best of 3: 230 msec per loop
+ python -m timeit -s 'import perf' 'perf.read_lrg_512_lzw()'
10 loops, best of 3: 200 msec per loop
+ python -m timeit -s 'import perf' 'perf.read_lrg_256_lzw()'
10 loops, best of 3: 233 msec per loop
+ python -m timeit -s 'import perf' 'perf.read_lrg_256_pb()'
10 loops, best of 3: 240 msec per loop
+ for size in '"lrg"' '"med"' '"sm"'
+ python -m timeit -s 'import perf' 'perf.read_med_1024_none()'
10 loops, best of 3: 37.9 msec per loop
+ python -m timeit -s 'import perf' 'perf.read_med_512_none()'
10 loops, best of 3: 26.4 msec per loop
+ python -m timeit -s 'import perf' 'perf.read_med_256_none()'
10 loops, best of 3: 36.3 msec per loop
+ python -m timeit -s 'import perf' 'perf.read_med_512_lzw()'
10 loops, best of 3: 28.1 msec per loop
+ python -m timeit -s 'import perf' 'perf.read_med_256_lzw()'
10 loops, best of 3: 31.4 msec per loop
+ python -m timeit -s 'import perf' 'perf.read_med_256_pb()'
10 loops, best of 3: 32.1 msec per loop
+ for size in '"lrg"' '"med"' '"sm"'
+ python -m timeit -s 'import perf' 'perf.read_sm_1024_none()'
100 loops, best of 3: 11.8 msec per loop
+ python -m timeit -s 'import perf' 'perf.read_sm_512_none()'
10 loops, best of 3: 12.7 msec per loop
+ python -m timeit -s 'import perf' 'perf.read_sm_256_none()'
10 loops, best of 3: 26.8 msec per loop
+ python -m timeit -s 'import perf' 'perf.read_sm_512_lzw()'
100 loops, best of 3: 9.99 msec per loop
+ python -m timeit -s 'import perf' 'perf.read_sm_256_lzw()'
10 loops, best of 3: 17.5 msec per loop
+ python -m timeit -s 'import perf' 'perf.read_sm_256_pb()'
10 loops, best of 3: 15.9 msec per loop
+ for size in '"lrg"' '"med"' '"sm"'
+ python -m timeit -s 'import perf_tile as perf' 'perf.read_lrg_1024_none()'
10 loops, best of 3: 166 msec per loop
+ python -m timeit -s 'import perf_tile as perf' 'perf.read_lrg_512_none()'
10 loops, best of 3: 144 msec per loop
+ python -m timeit -s 'import perf_tile as perf' 'perf.read_lrg_256_none()'
10 loops, best of 3: 191 msec per loop
+ python -m timeit -s 'import perf_tile as perf' 'perf.read_lrg_512_lzw()'
10 loops, best of 3: 144 msec per loop
+ python -m timeit -s 'import perf_tile as perf' 'perf.read_lrg_256_lzw()'
10 loops, best of 3: 175 msec per loop
+ python -m timeit -s 'import perf_tile as perf' 'perf.read_lrg_256_pb()'
10 loops, best of 3: 188 msec per loop
+ for size in '"lrg"' '"med"' '"sm"'
+ python -m timeit -s 'import perf_tile as perf' 'perf.read_med_1024_none()'
10 loops, best of 3: 32.9 msec per loop
+ python -m timeit -s 'import perf_tile as perf' 'perf.read_med_512_none()'
10 loops, best of 3: 22.9 msec per loop
+ python -m timeit -s 'import perf_tile as perf' 'perf.read_med_256_none()'
10 loops, best of 3: 30.7 msec per loop
+ python -m timeit -s 'import perf_tile as perf' 'perf.read_med_512_lzw()'
10 loops, best of 3: 23.1 msec per loop
+ python -m timeit -s 'import perf_tile as perf' 'perf.read_med_256_lzw()'
10 loops, best of 3: 27.9 msec per loop
+ python -m timeit -s 'import perf_tile as perf' 'perf.read_med_256_pb()'
10 loops, best of 3: 27.9 msec per loop
+ for size in '"lrg"' '"med"' '"sm"'
+ python -m timeit -s 'import perf_tile as perf' 'perf.read_sm_1024_none()'
10 loops, best of 3: 11.4 msec per loop
+ python -m timeit -s 'import perf_tile as perf' 'perf.read_sm_512_none()'
10 loops, best of 3: 11.2 msec per loop
+ python -m timeit -s 'import perf_tile as perf' 'perf.read_sm_256_none()'
10 loops, best of 3: 23 msec per loop
+ python -m timeit -s 'import perf_tile as perf' 'perf.read_sm_512_lzw()'
100 loops, best of 3: 9.76 msec per loop
+ python -m timeit -s 'import perf_tile as perf' 'perf.read_sm_256_lzw()'
10 loops, best of 3: 26.3 msec per loop
+ python -m timeit -s 'import perf_tile as perf' 'perf.read_sm_256_pb()'
100 loops, best of 3: 16.6 msec per loop
```
