### PR TITLE
Allow reading byte range windows of s3 hosted rasters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ bundle.js.map
 
 # MacOS
 .DS_Store
+
+# Lambda output
+dist/*.zip

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,7 @@ Vagrant.configure(2) do |config|
 
   # Sync a data directory which contains rasters on the host
   config.vm.synced_folder ENV['DATA_DIR'], "/vagrant/data"
+  config.vm.synced_folder "~/.aws", "/home/vagrant/.aws"
 
   # Change working directory to /vagrant upon session start.
   config.vm.provision "shell", inline: <<SCRIPT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,6 @@ services:
       - ./src/geop:/usr/src/geop
       - ./src/test_data:/usr/src/test_data
       - ./data:/usr/data
+      - $HOME/.aws:/root/.aws
+    environment:
+      AWS_PROFILE: "azavea-datahub"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,5 +24,6 @@ services:
       - ./src/geop:/usr/src/geop
       - ./src/test_data:/usr/src/test_data
       - $HOME/.aws:/root/.aws
+      - ./dist:/tmp/dist
     environment:
       AWS_PROFILE: "azavea-datahub"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,14 @@ services:
       - $HOME/.aws:/root/.aws
     environment:
       AWS_PROFILE: "azavea-datahub"
+  lambda:
+    image: srp-lambda-geop
+    build:
+      context: ./src
+      dockerfile: Dockerfile.lambda
+    volumes:
+      - ./src/geop:/usr/src/geop
+      - ./src/test_data:/usr/src/test_data
+      - $HOME/.aws:/root/.aws
+    environment:
+      AWS_PROFILE: "azavea-datahub"

--- a/scripts/makezip
+++ b/scripts/makezip
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker-compose build lambda
+docker-compose run --rm -T lambda mv /tmp/rasterio-1.0a4.amzn1.zip /tmp/dist

--- a/src/Dockerfile.geop
+++ b/src/Dockerfile.geop
@@ -2,11 +2,23 @@ FROM quay.io/azavea/flask:0.11
 
 MAINTAINER Azavea
 
+ENV GDAL_VERSION 2.1.2
+
 RUN \
       apt-get update && apt-get install -y --no-install-recommends \
-              gdal-bin \
-              libgdal-dev \
+              wget \
+              build-essential \
+              python-dev \
+              libgeos-dev \
+              libexpat1 \
       && rm -rf /var/lib/apt/lists/*
+
+RUN \
+      wget -qO- http://download.osgeo.org/gdal/${GDAL_VERSION}/gdal-${GDAL_VERSION}.tar.gz \
+      | tar -xzC /usr/src \
+      && cd /usr/src/gdal-${GDAL_VERSION} \
+      && ./configure --with-python \
+      && make install
 
 COPY requirements.txt /tmp/
 
@@ -14,9 +26,18 @@ RUN \
       pip install --no-cache-dir \
           numpy==$(grep "numpy" /tmp/requirements.txt | cut -d= -f3) \
       && pip install --no-cache-dir -r /tmp/requirements.txt \
-      && rm /tmp/requirements.txt \
-      && apt-get purge -y --auto-remove \
-                 libgdal-dev
+      && rm /tmp/requirements.txt
+
+RUN \
+      apt-get purge -y --auto-remove \
+                 python-dev \
+                 build-essential \
+                 wget
+
+# VSI S3 urls trigger CURL error: error setting certificate verify locations
+RUN \
+      mkdir -p /etc/pki/tls/certs/ \
+      && ln -s /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt
 
 COPY ./geop /usr/src/geop
 COPY ./geop /usr/src/test_data

--- a/src/Dockerfile.geop
+++ b/src/Dockerfile.geop
@@ -6,19 +6,8 @@ ENV GDAL_VERSION 2.1.2
 
 RUN \
       apt-get update && apt-get install -y --no-install-recommends \
-              wget \
               build-essential \
-              python-dev \
-              libgeos-dev \
-              libexpat1 \
       && rm -rf /var/lib/apt/lists/*
-
-RUN \
-      wget -qO- http://download.osgeo.org/gdal/${GDAL_VERSION}/gdal-${GDAL_VERSION}.tar.gz \
-      | tar -xzC /usr/src \
-      && cd /usr/src/gdal-${GDAL_VERSION} \
-      && ./configure --with-python \
-      && make install
 
 COPY requirements.txt /tmp/
 
@@ -30,9 +19,7 @@ RUN \
 
 RUN \
       apt-get purge -y --auto-remove \
-                 python-dev \
-                 build-essential \
-                 wget
+                 build-essential
 
 # VSI S3 urls trigger CURL error: error setting certificate verify locations
 RUN \

--- a/src/Dockerfile.lambda
+++ b/src/Dockerfile.lambda
@@ -21,6 +21,8 @@ RUN \
 RUN \
     /builder/bin/pip --no-cache-dir install pyproj
 
+COPY ./geop /usr/src/geop
+
 RUN \
     cd /builder/lib/python2.7/site-packages \
     && zip -9 -r /tmp/rasterio-${RASTERIO_VERSION}.amzn1.zip * \
@@ -32,4 +34,11 @@ RUN \
            -x /jmespath* \
            -x /pkg_resources* \
     && cd /builder/lib64/python2.7/site-packages/ \
-    && zip -9 -r /tmp/rasterio-${RASTERIO_VERSION}.amzn1.zip *
+    && zip -9 -r /tmp/rasterio-${RASTERIO_VERSION}.amzn1.zip * \
+    && cd /usr/src/geop/ \
+    && zip -9 -r /tmp/rasterio-${RASTERIO_VERSION}.amzn1.zip \
+           lambda.py \
+           geoprocessing.py \
+           geo_utils.py \
+           request_utils.py \
+           errors.py

--- a/src/Dockerfile.lambda
+++ b/src/Dockerfile.lambda
@@ -1,0 +1,35 @@
+FROM amazonlinux:latest
+
+RUN \
+    yum install -y \
+        gcc \
+        python27-virtualenv \
+        zip \
+    && virtualenv builder \
+    && cd builder \
+    && /builder/bin/pip --no-cache-dir install --upgrade pip
+
+ENV RASTERIO_VERSION 1.0a4
+ENV SHAPELY_VERSION 1.6b2
+
+RUN \
+    /builder/bin/pip --no-cache-dir install rasterio[s3]==${RASTERIO_VERSION}
+
+RUN \
+    /builder/bin/pip --no-cache-dir install shapely==${SHAPELY_VERSION}
+
+RUN \
+    /builder/bin/pip --no-cache-dir install pyproj
+
+RUN \
+    cd /builder/lib/python2.7/site-packages \
+    && zip -9 -r /tmp/rasterio-${RASTERIO_VERSION}.amzn1.zip * \
+           -x /boto* \
+           -x /pip* \
+           -x /docutils* \
+           -x /s3transfer* \
+           -x /setuptools* \
+           -x /jmespath* \
+           -x /pkg_resources* \
+    && cd /builder/lib64/python2.7/site-packages/ \
+    && zip -9 -r /tmp/rasterio-${RASTERIO_VERSION}.amzn1.zip *

--- a/src/geop/geo_utils.py
+++ b/src/geop/geo_utils.py
@@ -110,7 +110,7 @@ def get_window_and_affine(geom, raster_src):
     # Create an affine transformation relative to that window.  Still a little
     # opaque to me and lifted from:
     # https://snorfalorpagus.net/blog/2014/11/09/masking-rasterio-layers-with-vector-features/
-    t = raster_src.affine
+    t = raster_src.transform
     c = t.c + ul[1] * t.a
     f = t.f + lr[0] * t.e
     shifted_affine = Affine(t.a, t.b, c, t.d, t.e, f)

--- a/src/geop/geoprocessing.py
+++ b/src/geop/geoprocessing.py
@@ -2,10 +2,7 @@ import collections
 import numpy as np
 import rasterio
 
-from PIL import Image
-from io import BytesIO
-
-from geo_utils import mask_geom_on_raster, tile_read
+from geo_utils import mask_geom_on_raster
 
 
 def count(geom, raster_path, modifications=None):
@@ -268,47 +265,3 @@ def statistics(geom, raster_path, stat):
         return layer.std()
     else:
         raise Exception("{0} has not been implemented".format(stat))
-
-
-def render_tile(geom, raster_path, user_palette):
-    """
-    Generates a visual PNG map tile from a vector polygon
-
-    Args:
-        geom (Shapely Geometry): A polygon corresponding to a TMS tile
-            request boundary
-
-        raster_path (string): A local file path to a raster in EPSG:3857
-            to generate visual tile from
-
-        uer_palette (optional list): A sequence of RGB triplets whose index
-            corresponds to the raster value which will be rendered. If
-            provided, will override a ColorTable defined in the raster
-    Returns:
-        Byte Array of image in the PNG format
-    """
-    tile, palette = tile_read(geom, raster_path)
-    return render_tile_from_data(tile, user_palette or palette)
-
-
-def render_tile_from_data(tile, palette):
-    """
-    Generates a visual PNG map tile from an ndarray of raster data
-
-    Args:
-        tile (ndarray) : A square 256x256 array of raster values
-
-        palette (list<int>): A list of RGB values to render `tile`
-
-    Returns:
-        Byte Array of image in the PNG format
-    """
-    img = Image.fromarray(tile, mode='P')
-
-    if len(palette):
-        img.putpalette(palette)
-
-    img_data = BytesIO()
-    img.save(img_data, 'png')
-    img_data.seek(0)
-    return img_data

--- a/src/geop/lambda.py
+++ b/src/geop/lambda.py
@@ -1,0 +1,56 @@
+from __future__ import print_function
+from __future__ import division
+
+from request_utils import parse_config
+import geoprocessing
+
+
+def handler(body, context):
+    """
+    Perform a cell count analysis on a portion of a provided raster.
+    If `modifications` is present on the input payload, apply those
+    modification values to the raster before performing the count.
+    """
+
+    # Due to differences in lamda and api gateway test interface, this
+    # may be parsed json or a string
+    user_input = parse_config(body)
+    geom = user_input['query_polygon']
+    layers = user_input['raster_paths']
+    mods = user_input['mods']
+
+    method = body['method']
+
+    if method == 'count':
+        return count(geom, layers[0], mods)
+
+
+def count(geom, raster_path, mods):
+    total, count_map = geoprocessing.count(geom, raster_path, mods)
+
+    return {
+        'cellCount': total,
+        'counts': count_map,
+    }
+
+
+if __name__ == '__main__':
+    """
+    Simple check against the above function intended for lambda execution
+    """
+    url = "s3://simple-raster-processing/nlcd_512_lzw_tiled.tif"
+    body = {
+            "method": "count",
+            "rasters": [url],
+            "queryPolygon": {
+                "type": "Polygon",
+                "coordinates": [[[-75.26870727539062, 39.876546372401194],
+                                 [-75.26870727539062, 40.05127080263306],
+                                 [-75.03868103027344, 40.05127080263306],
+                                 [-75.03868103027344, 39.876546372401194],
+                                 [-75.26870727539062, 39.876546372401194]]]
+              }
+         }
+
+    print(body)  # Output can be used in API Gateway test UI
+    print(handler(body, None))

--- a/src/geop/main.py
+++ b/src/geop/main.py
@@ -1,5 +1,3 @@
-import time
-
 from flask import Flask, request, jsonify, send_file
 import numpy as np
 
@@ -23,7 +21,6 @@ def count():
     """
     user_input = parse_config(request)
 
-    start = time.clock()
     geom = user_input['query_polygon']
     raster_path = user_input['raster_paths'][0]
     mods = user_input['mods']
@@ -31,7 +28,6 @@ def count():
     total, count_map = geoprocessing.count(geom, raster_path, mods)
 
     return jsonify({
-        'time': time.clock() - start,
         'cellCount': total,
         'counts': count_map,
     })
@@ -46,14 +42,12 @@ def pair_counts():
     """
     user_input = parse_config(request)
 
-    start = time.clock()
     geom = user_input['query_polygon']
     raster_paths = user_input['raster_paths']
 
     pair_map = geoprocessing.count_pairs(geom, raster_paths)
 
     return jsonify({
-        'time': time.clock() - start,
         'pairs': pair_map
     })
 
@@ -65,14 +59,12 @@ def xy():
     """
     user_input = parse_config(request)
 
-    start = time.clock()
     geom = user_input['query_polygon']
     raster_path = user_input['raster_paths'][0]
 
     value = geoprocessing.sample_at_point(geom, raster_path)
 
     return jsonify({
-        'time': time.clock() - start,
         'value': value
     })
 
@@ -84,14 +76,12 @@ def stats(stat):
     """
     user_input = parse_config(request)
 
-    start = time.clock()
     geom = user_input['query_polygon']
     raster_path = user_input['raster_paths'][0]
 
     value = geoprocessing.statistics(geom, raster_path, stat)
 
     return jsonify({
-        'time': time.clock() - start,
         'stat': stat,
         'value': value
     })

--- a/src/geop/main.py
+++ b/src/geop/main.py
@@ -107,6 +107,8 @@ def layer_tile(layer, z, x, y):
     user_palette = None
     if layer == 'nlcd':
         path = '/usr/data/nlcd/nlcd_webm_512.tif'
+    elif layer == 'nlcd_s3':
+        path = 's3://simple-raster-processing/nlcd_webm_512.tif'
     elif layer == 'soil':
         path = '/usr/data/hydro_soils_webm_512.tif'
         user_palette = [255,255,255, 255,255,212, 254,227,145, 204,76,2, 140,45,4, 254,196,79, 254,153,41, 236,112,20]  # noqa

--- a/src/geop/main.py
+++ b/src/geop/main.py
@@ -4,6 +4,7 @@ from flask import Flask, request, jsonify, send_file
 import numpy as np
 
 import geoprocessing
+import tiles
 
 from errors import UserInputError
 from geo_utils import tile_to_bbox, tile_read
@@ -117,7 +118,7 @@ def layer_tile(layer, z, x, y):
 
     bbox = tile_to_bbox(z, x, y)
 
-    img = geoprocessing.render_tile(bbox, path, user_palette)
+    img = tiles.render_tile(bbox, path, user_palette)
     return send_file(img, mimetype='image/png')
 
 
@@ -137,7 +138,7 @@ def reclass_tile(z, x, y):
     geoprocessing.reclassify_from_data(tile, substitutions)
 
     # Render new tiles using the reclassified nlcd data
-    img = geoprocessing.render_tile_from_data(tile, palette)
+    img = tiles.render_tile_from_data(tile, palette)
     return send_file(img, mimetype='image/png')
 
 
@@ -197,7 +198,7 @@ def priority(z, x, y):
     palette = [255,255,255, 0,104,55, 26,152,80, 102,189,99, 166,217,106, 217,239,139, 254,224,139, 253,174,97, 244,109,67, 215,48,39, 165,0,38]  # noqa
 
     # Render the image tile for this priority map with the new palette
-    img = geoprocessing.render_tile_from_data(priority_rounded, palette)
+    img = tiles.render_tile_from_data(priority_rounded, palette)
     return send_file(img, mimetype='image/png')
 
 

--- a/src/geop/request_utils.py
+++ b/src/geop/request_utils.py
@@ -9,6 +9,9 @@ DEFAULT_SRS = 'epsg:5070'
 
 
 def get_path(raster_name):
+    if raster_name[:2] == 's3':
+        return raster_name
+
     raster_path = os.path.join(DATA_PATH, raster_name)
     if not os.path.isfile(raster_path):
         raise UserInputError(

--- a/src/geop/request_utils.py
+++ b/src/geop/request_utils.py
@@ -30,7 +30,10 @@ def parse_config(request):
 
     """
 
-    req_config = request.get_json(silent=True)
+    if 'get_json' in request:
+        req_config = request.get_json(silent=True)
+    else:
+        req_config = request
 
     if req_config:
         rasters = req_config.get('rasters', None)

--- a/src/geop/tests.py
+++ b/src/geop/tests.py
@@ -253,5 +253,27 @@ class ImageTests(unittest.TestCase):
         self.assertItemsEqual(palette[765:768], colormap[255][0:3])
 
 
+class S3Tests(unittest.TestCase):
+    def setUp(self):
+        self.url = 's3://simple-raster-processing/nlcd_512_lzw_tiled.tif'
+        self.geom = Polygon([
+            [1747260.99651947943493724, 2071928.23170474520884454],
+            [1747260.99651947943493724, 2071884.15942327585071325],
+            [1747323.9569215786177665, 2071882.06074320594780147],
+            [1747321.85824150871485472, 2071927.53214472183026373],
+            [1747260.99651947943493724, 2071928.23170474520884454]])
+
+
+    def test_read_count(self):
+        """Test a small byte offset raster read using vsicurl s3 url"""
+
+        _, s3_counts = geoprocessing.count(self.geom, self.url)
+        _, disk_counts = geoprocessing.count(self.geom, NLCD_PATH)
+
+        self.assertDictEqual(s3_counts, disk_counts,
+                             "Reading the same offset from a local and s3 " +
+                             "file did not produce equivalent results")
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/geop/tiles.py
+++ b/src/geop/tiles.py
@@ -1,0 +1,48 @@
+from PIL import Image
+from io import BytesIO
+
+from geo_utils import tile_read
+
+
+def render_tile(geom, raster_path, user_palette):
+    """
+    Generates a visual PNG map tile from a vector polygon
+
+    Args:
+        geom (Shapely Geometry): A polygon corresponding to a TMS tile
+            request boundary
+
+        raster_path (string): A local file path to a raster in EPSG:3857
+            to generate visual tile from
+
+        uer_palette (optional list): A sequence of RGB triplets whose index
+            corresponds to the raster value which will be rendered. If
+            provided, will override a ColorTable defined in the raster
+    Returns:
+        Byte Array of image in the PNG format
+    """
+    tile, palette = tile_read(geom, raster_path)
+    return render_tile_from_data(tile, user_palette or palette)
+
+
+def render_tile_from_data(tile, palette):
+    """
+    Generates a visual PNG map tile from an ndarray of raster data
+
+    Args:
+        tile (ndarray) : A square 256x256 array of raster values
+
+        palette (list<int>): A list of RGB values to render `tile`
+
+    Returns:
+        Byte Array of image in the PNG format
+    """
+    img = Image.fromarray(tile, mode='P')
+
+    if len(palette):
+        img.putpalette(palette)
+
+    img_data = BytesIO()
+    img.save(img_data, 'png')
+    img_data.seek(0)
+    return img_data

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,70 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Demo Lambda Geoprocessing</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.2/leaflet.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.4.7/leaflet.draw.css" />
+</head>
+
+<body>
+  <h4>Draw a shape below to perform a census on the NLCD raster</h4>
+  <p>Output in console</p>
+  <div id="map" style="height:700px; width:900px"></div>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.2/leaflet.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.4.7/leaflet.draw.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+
+  <script>
+    var map = L.map('map', {center: [39.9, -75.2], zoom: 10}),
+        base = L.tileLayer('https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png').addTo(map),
+        overlays = {
+            NLCD: L.tileLayer('https://{s}.tiles.azavea.com/nlcd/{z}/{x}/{y}.png', {opacity: 0.7}),
+            Soil: L.tileLayer('https://{s}.tiles.azavea.com/ssurgo-hydro-group-30m/{z}/{x}/{y}.png', {opacity: 0.7}),
+        },
+        drawnItems = L.featureGroup().addTo(map),
+        url = 'https://wb85ky8g56.execute-api.us-east-1.amazonaws.com/demo',
+        req = {
+            method: 'count',
+            rasters: ['s3://simple-raster-processing/nlcd_512_lzw_tiled.tif'],
+
+        };
+
+    $.ajaxSetup({
+        headers: {'X-API-KEY': 'xxxxx2IR97XenjMY'},
+        contentType: 'application/json'
+    });
+
+    L.control.layers(null, overlays).addTo(map);
+
+    map.addControl(new L.Control.Draw({
+        draw: {
+            marker: false,
+            polyline: false,
+            circle: false,
+            polygon: false
+        }
+    }));
+
+    map.on(L.Draw.Event.DRAWSTART, function (e) {
+        drawnItems.clearLayers();
+    });
+
+    map.on(L.Draw.Event.CREATED, function (e) {
+        drawnItems.addLayer(e.layer);
+        req.queryPolygon = e.layer.toGeoJSON().geometry;
+
+        $.post(url, JSON.stringify(req))
+            .done(function(resp) {
+                console.log(resp);
+            })
+            .fail(function(error) {
+                console.error(error);
+            });
+    });
+
+  </script>
+</body>
+</html>

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,4 +4,4 @@ numpy==1.11.1
 rasterio[s3]==1.0a4
 requests==2.10.0
 scipy==0.18
-shapely==1.5.15
+shapely==1.6b2

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,7 +1,7 @@
 pillow==3.3.1
 pyproj==1.9.5.1
 numpy==1.11.1
-rasterio==0.36.0
+rasterio[s3]==1.0a4
 requests==2.10.0
 scipy==0.18
 shapely==1.5.15


### PR DESCRIPTION
#### Overview
Upgrades GDAL and rasterio to versions which support windowed reads on s3, and some updates to the demonstration code to test it out.  The performance with network latency is obviously significantly slower than disk reads, but for a city sized area (~150 mi<sup>2</sup>) it adds about 1sec on my dev workstation, which is palatable.  The ultimate goal with this path is to try and develop an AWS Lambda function which could do this processioning with a tradeoff for scalability at the expense of some performance. 

If you want to try it out:
* Make sure you have an `azavea-datahub` profile with access to the account which contains the `simple-raster-processing` bucket
* Rebuild the container and get some :coffee: while GDAL builds
* After bringing up a container, run the tests `docker-compose exec python tests.py`
* Test the s3 read on dynamic tiling (I'd zoom in level 10 or closer if you want reasonable performance)
   * geojson.io > Meta > Add Map Layer: http://localhost:8080/nlcd_s3/{z}/{x}/{y}.png
* Test a rest endpoint

```bash
curl -X POST -H "Content-Type: application/json" -d '{
    "rasters": ["s3://simple-raster-processing/nlcd_512_lzw_tiled.tif"],
    "queryPolygon":
    {
        "type": "Polygon",
        "coordinates": [
          [
            [ -75.26870727539062, 39.876546372401194 ],
            [ -75.26870727539062, 40.05127080263306 ],
            [ -75.03868103027344, 40.05127080263306 ],
            [ -75.03868103027344, 39.876546372401194 ],
            [ -75.26870727539062, 39.876546372401194 ]
          ]
        ]
      }
}' "http://localhost:8080/counts"
```
Which does a census against this shape:

![screenshot from 2016-12-17 00 07 16](https://cloud.githubusercontent.com/assets/1014341/21284553/d14c8fb4-c3ec-11e6-9f48-f8fb297a6ad3.png)

